### PR TITLE
Add toggle-all-overlays toolbar button

### DIFF
--- a/src/components/ToolMenu/ToolMenu.jsx
+++ b/src/components/ToolMenu/ToolMenu.jsx
@@ -42,7 +42,7 @@ import {
 import { BsArrowUpLeft } from "react-icons/bs";
 import { FiSun, FiSunset, FiZoomIn, FiRotateCw } from "react-icons/fi";
 import { IoMdEgg } from "react-icons/io";
-import { MdLoop, MdPanTool, MdMyLocation, MdOutlineKeyboardCommandKey } from "react-icons/md";
+import { MdLoop, MdPanTool, MdMyLocation, MdOutlineKeyboardCommandKey, MdOutlineLayersClear, MdOutlineLayers } from "react-icons/md";
 import { TbReplace, TbReorder, TbContrast2 } from "react-icons/tb";
 import {
   TiDeleteOutline,
@@ -54,7 +54,7 @@ import { MdWbIridescent } from "react-icons/md";
 import AnnotationList from "../annotationsList";
 import ResizeAndDrag from "../management/common/resizeAndDrag";
 import CustomModal from "../management/common/resizeAndDrag";
-import { clearGrid } from "../annotationsList/action";
+import { clearGrid, toggleAllOverlays } from "../annotationsList/action";
 import Spinner from "../common/circleSpinner";
 import "../../font-icons/styles.css";
 import "react-input-range/lib/css/index.css";
@@ -73,7 +73,8 @@ const mapStateToProps = (state) => {
     patients: state.annotationsListReducer.patients,
     patientLoading: state.annotationsListReducer.patientLoading,
     activePort: state.annotationsListReducer.activePort,
-    lastLocation: state.annotationsListReducer.lastLocation
+    lastLocation: state.annotationsListReducer.lastLocation,
+    isAllOverlayHidden: state.annotationsListReducer.isAllOverlayHidden,
   };
 };
 
@@ -811,6 +812,20 @@ class ToolMenu extends Component {
             />
           );
         })}
+        <div
+          id="toggleAllOverlays"
+          tabIndex="12"
+          className={this.props.isAllOverlayHidden ? "toolbarSectionButton_Active" : "toolbarSectionButton"}
+          onClick={() => this.props.dispatch(toggleAllOverlays())}
+          title={this.props.isAllOverlayHidden ? "Show overlays on all viewports" : "Hide overlays on all viewports"}
+        >
+          <div className="toolContainer">
+            {this.props.isAllOverlayHidden ? <MdOutlineLayers /> : <MdOutlineLayersClear />}
+          </div>
+          <div className="buttonLabel">
+            <span>{this.props.isAllOverlayHidden ? "Show Info" : "Hide Info"}</span>
+          </div>
+        </div>
         {/* <div
                         id="point"
                         tabIndex="1"

--- a/src/components/annotationsList/action.js
+++ b/src/components/annotationsList/action.js
@@ -62,6 +62,7 @@ import {
   SET_PAGE_ORDER_SERIES,
   SET_PAGE_ORDER,
   CLEAR_PAGE_ORDER_SERIES,
+  TOGGLE_ALL_OVERLAYS,
   colors,
   commonLabels,
 } from "./types";
@@ -497,6 +498,8 @@ export const toggleAllCalculations = (checked) => {
     payload: { checked },
   };
 };
+
+export const toggleAllOverlays = () => ({ type: TOGGLE_ALL_OVERLAYS });
 
 // invoked at display view right bar
 export const toggleSingleLabel = (serieID, aimID) => {

--- a/src/components/annotationsList/reducer.js
+++ b/src/components/annotationsList/reducer.js
@@ -63,6 +63,7 @@ import {
   SET_PAGE_ORDER_SERIES,
   SET_PAGE_ORDER,
   CLEAR_PAGE_ORDER_SERIES,
+  TOGGLE_ALL_OVERLAYS,
   colors,
   commonLabels,
 } from "./types";
@@ -123,6 +124,7 @@ const initialState = {
   mammogramPageIndex: 0,
   pageOrderSeries: [],
   currentPageOrder: 1,
+  isAllOverlayHidden: false,
 };
 
 
@@ -160,6 +162,8 @@ const asyncReducer = (state = initialState, action) => {
         return { ...state, lastLocation: action.lastLocation };
       case TOGGLE_ALL_CALCULATIONS:
         return { ...state, showCalculations: action.payload.checked };
+      case TOGGLE_ALL_OVERLAYS:
+        return { ...state, isAllOverlayHidden: !state.isAllOverlayHidden };
       case STORE_AIM_SELECTION_ALL:
         const { checked, map, tbPageIndex, clearAll } = action.payload;
         let newMultipageAimSelectionAll = _.cloneDeep(state.multipageAimSelection);
@@ -734,6 +738,7 @@ const asyncReducer = (state = initialState, action) => {
           showCalculations: false,
           showLabels: false,
           showAnnotations: mode === 'teaching' ? false : true,
+          isAllOverlayHidden: false,
         };
       case CLEAR_SELECTION:
         let selectionState = { ...state };

--- a/src/components/annotationsList/types.js
+++ b/src/components/annotationsList/types.js
@@ -75,6 +75,7 @@ export const CLEAR_MAMMOGRAM_SERIES = 'epadjs/annotationList/CLEAR_MAMMOGRAM_SER
 export const SET_PAGE_ORDER_SERIES = 'epadjs/annotationList/SET_PAGE_ORDER_SERIES';
 export const SET_PAGE_ORDER = 'epadjs/annotationList/SET_PAGE_ORDER';
 export const CLEAR_PAGE_ORDER_SERIES = 'epadjs/annotationList/CLEAR_PAGE_ORDER_SERIES';
+export const TOGGLE_ALL_OVERLAYS = 'epadjs/annotationList/TOGGLE_ALL_OVERLAYS';
 
 export const commonLabels = {
   button: { background: "#6c757d", color: "#ECECEC", border: "#acacac solid 1px" },

--- a/src/components/display/displayView.jsx
+++ b/src/components/display/displayView.jsx
@@ -175,6 +175,7 @@ const mapStateToProps = (state) => {
     mammogramPageIndex: state.annotationsListReducer.mammogramPageIndex,
     pageOrderSeries: state.annotationsListReducer.pageOrderSeries,
     currentPageOrder: state.annotationsListReducer.currentPageOrder,
+    isAllOverlayHidden: state.annotationsListReducer.isAllOverlayHidden,
   };
 };
 
@@ -2944,8 +2945,8 @@ class DisplayView extends Component {
   toggleOverlay = (e, i) => {
     const showHide = { ...this.state.isOverlayVisible };
     const index = i || i === 0 ? i : this.props.activePort;
-    if (showHide[index]) delete showHide[index];
-    else showHide[index] = true;
+    if (showHide[index] === false) delete showHide[index];
+    else showHide[index] = false;
     this.setState({ isOverlayVisible: showHide });
   };
 
@@ -3829,7 +3830,7 @@ class DisplayView extends Component {
                     style={{ height: "calc(100% - 26px)" }}
                     activeTool={activeTool}
                     showingPHI={this.props.showingPHI && mode === 'teaching'}
-                    isOverlayVisible={this.state.isOverlayVisible[i] || false}
+                    isOverlayVisible={!this.props.isAllOverlayHidden && (this.state.isOverlayVisible[i] !== false)}
                     jumpToImage={() => this.jumpToImage(0, i)}
                   />}
                 </div>


### PR DESCRIPTION
  - Add TOGGLE_ALL_OVERLAYS Redux action/reducer to persist overlay state across navigation
  - Add Hide All/Show All button in ToolMenu after Save State, using MdOutlineLayersClear/MdOutlineLayers icons
  - Fix toggleOverlay to store false (hidden) instead of true, so the prop defaults to true and changes are detected by CornerstoneViewport — also fixes per-viewport toggle from requiring 2 clicks to 1